### PR TITLE
Refactored header-check in csv 

### DIFF
--- a/internal/encoder/csv.go
+++ b/internal/encoder/csv.go
@@ -157,20 +157,21 @@ func (dec *CsvDecoder) Read(p []byte) (n int, err error) {
 	var headerLine []string
 	var record []string
 	// create headerline from config or from read.
-	if dec.backend.CsvConfig.Header {
-		if dec.headerline == nil {
+	if dec.headerline == nil {
+		if dec.backend.CsvConfig.Header {
 			headerLine, err = dec.csvreader.Read()
 			if err == nil {
 				dec.headerline = headerLine
 			}
+		} else if !dec.backend.CsvConfig.Header {
+			if dec.backend.CsvConfig.Order != nil {
+				dec.headerline = dec.backend.CsvConfig.Order
+			}
+		} else {
+			dec.logger.Warnf("No strategy chosen for headers chosen, please change config")
 		}
-	} else if !dec.backend.CsvConfig.Header {
-		if dec.backend.CsvConfig.Order != nil {
-			dec.headerline = append(dec.headerline, dec.backend.CsvConfig.Order...)
-		}
-	} else {
-		dec.logger.Warnf("No strategy chosen for headers chosen, please change config")
 	}
+
 	//streaming doesnt work with ReadAll()
 	// append one entity per line, comma separated
 	for {

--- a/internal/encoder/csv.go
+++ b/internal/encoder/csv.go
@@ -168,7 +168,7 @@ func (dec *CsvDecoder) Read(p []byte) (n int, err error) {
 				dec.headerline = dec.backend.CsvConfig.Order
 			}
 		} else {
-			dec.logger.Warnf("No strategy chosen for headers chosen, please change config")
+			dec.logger.Errorf("No strategy chosen for headers chosen, please change config")
 		}
 	}
 


### PR DESCRIPTION
This is done to avoid reading the same header multiple times.
