### PR TITLE
fix: avoid continuation producing overhang

### DIFF
--- a/internal/encoder/flatFile.go
+++ b/internal/encoder/flatFile.go
@@ -223,16 +223,17 @@ func (d *FlatFileDecoder) Read(p []byte) (n int, err error) {
 	} else {
 		token = d.since
 	}
-	// Add continuation token
-	entity := map[string]interface{}{
-		"id":    "@continuation",
-		"token": token,
-	}
-	sinceBytes, err := json.Marshal(entity)
-	buf = append(buf, append([]byte(","), sinceBytes...)...)
 
 	// close json array
 	if !d.closed {
+		// Add continuation token
+		entity := map[string]interface{}{
+			"id":    "@continuation",
+			"token": token,
+		}
+		sinceBytes, _ := json.Marshal(entity)
+		buf = append(buf, append([]byte(","), sinceBytes...)...)
+
 		buf = append(buf, []byte("]")...)
 		d.closed = true
 		if n, err, done = d.flush(p, buf); done {

--- a/internal/encoder/parquet.go
+++ b/internal/encoder/parquet.go
@@ -302,16 +302,16 @@ func (d *ParquetDecoder) Read(p []byte) (n int, err error) {
 	} else {
 		token = d.since
 	}
-	// Add continuation token
-	continueEntity := map[string]interface{}{
-		"id":    "@continuation",
-		"token": token,
-	}
-	sinceBytes, err := json.Marshal(continueEntity)
-	buf = append(buf, append([]byte(","), sinceBytes...)...)
 
 	// close json array
 	if !d.closed {
+		// Add continuation token
+		continueEntity := map[string]interface{}{
+			"id":    "@continuation",
+			"token": token,
+		}
+		sinceBytes, _ := json.Marshal(continueEntity)
+		buf = append(buf, append([]byte(","), sinceBytes...)...)
 		buf = append(buf, []byte("]")...)
 		d.closed = true
 		if n, err, done = d.flush(p, buf); done {


### PR DESCRIPTION
when the source stream in a reader is exhausted, and the addition of a continuation to the output buffer would create overhang, then the response would become invalid. because the overhang would trigger one more read call which would append the continuation one more time. this fix fix makes sure we dont add an additional continuation in these cases.