### PR TITLE
chore: Use slices package from standard library

### DIFF
--- a/internal/encoder/decoder.go
+++ b/internal/encoder/decoder.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/mimiro-io/objectstorage-datalayer/internal/conf"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 type EncodingEntityReader interface {


### PR DESCRIPTION
The [slices](https://go.dev/doc/go1.21#slices) package was added to the Go standard library in 1.21, so let's use that instead of the older `x/exp/slices` package