### PR TITLE
add support for custom filenames to flatfile and csv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3   as builder
+FROM golang:1.23   as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Depending on storage type and security requirements the configuration of each da
             "Long." : "longitude"
         },
         "columnTypes" : {
-            "coordinates" : "float",  
+            "coordinates" : "float",
             "latitude" : "float",
             "longitude" : "float"
         },
@@ -215,6 +215,7 @@ Depending on storage type and security requirements the configuration of each da
         },
     },
     "flatFile": {
+        "customFileName": "FOO",
         "fields": {
             "birthdate": {
                 "substring": [[0,8]]
@@ -246,7 +247,7 @@ property name | description
 `dataset` |  name of the dataset.
 `storageType` | `S3` or `Azure`. Note that other types will not produce an error, uploaded data will be logged to server logs instead.
 `stripProps` | only relevant for json encoded datasets. Csv and Parquet will implicitly set this to true. If true, the layer will transform each uploaded entity such that only properties are stored, and all property keys have their prefixes removed. If false, the complete entities are stored. Default false
-`resolveNamespace` | Resolve namespace ref to full uri in id and references. It will **not** resolve namespace in props. 
+`resolveNamespace` | Resolve namespace ref to full uri in id and references. It will **not** resolve namespace in props.
 `storeDeleted` | If true, entities with the deleted flag are included in the stored object. If false, they are filtered out by the layer. Default false. Should only ever be set to true for unstripped json encoded datasets.
 `athenaCompatible` | reformat json batches as newline-delimited lists of json objects (ndjson). Default false
 `csv` | if not empty, the layer will use a csv encoder to transform entities into csv files. If both parquet and csv config objects are present, parquet has precedence.
@@ -254,6 +255,7 @@ property name | description
 `csv.encoding` | overide csv file character encoding. default UTF-8
 `csv.separator` | set a csv delimiter. default is comma. should only be a single character.
 `csv.order` | array of properties to include in given order in csv  file. each array element has to map to a stripped property name in the given entities.
+`csv.customFileName` | sets a custom string after the recorded timestamp in the file name i.e 1723634100068669184-<XXX>.csv when writing to s3.
 `parquet` | if not empty, the layer will use a parquet encoder to transform entities into parquet files. If both parquet and csv config objects are present, parquet has precedence.
 `parquet.schema` | a parquet schema string. each column name must match a stripped property or reference name in the given entities. `id` will use entity id unless a prop with name id is defined on the entity.
 `parquet.flushThreshold` | override number of bytes after which parquet streams are flushed to the storage target. Default is 1MB. The higher this value is set, the more optimized parquet read performance will be. But higher flushThreshold also means more memory buildup. for a typical layer installation 64MB is a recommended max.
@@ -286,6 +288,7 @@ property name | description
 `flatFile.fields.decimals` | Can be used to declare how many decimals in a parsed float.
 `flatFile.fields.dateLayout` | Must be present for parsing date. Declare with standard go date format layout.
 `flatFile.continueOnParseError` | If set to true, the line parser will log a warning and continue to parse the rest of the file on error. Default: false
+`flatFile.customFileName` | sets a custom string after the recorded timestamp in the file name i.e 1723634100068669184-<XXX>.txt when writing to s3.
 
 #### Encoders.
 
@@ -322,7 +325,7 @@ must be provided like this:
   }
 }
 ```
-By default when id is defined in the schema, it will use the entity id. This can be overridden by adding a property called `id`. 
+By default when id is defined in the schema, it will use the entity id. This can be overridden by adding a property called `id`.
 _When using the default entity id, the schema type must be string as entity ids, will always be strings:_
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mimiro-io/objectstorage-datalayer
 
-go 1.22.3
+go 1.23
 
 require (
 	github.com/Azure/azure-storage-blob-go v0.15.0

--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -62,6 +62,7 @@ type CsvConfig struct {
 	Order          []string `json:"order"`
 	SkipRows       int      `json:"skiprows"`
 	ValidateFields bool     `json:"validatefields"`
+	CustomFileName string   `json:"customFileName"`
 }
 
 type ParquetConfig struct {
@@ -74,6 +75,7 @@ type FlatFileConfig struct {
 	Fields               map[string]FlatFileField `json:"fields"`
 	FieldOrder           []string                 `json:"fieldOrder"`
 	ContinueOnParseError bool                     `json:"continueOnParseError"`
+	CustomFileName       string                   `json:"customFileName"`
 }
 
 type FlatFileField struct {

--- a/internal/store/s3.go
+++ b/internal/store/s3.go
@@ -285,12 +285,20 @@ func (s3s *S3Storage) createKey(entities []*uda.Entity, fullSync bool) string {
 		}
 	}
 
+	filename := ""
+
 	ending := "json"
 	if s3s.config.CsvConfig != nil {
 		ending = "csv"
+		if s3s.config.FlatFileConfig.CustomFileName != "" {
+			filename = fmt.Sprintf("%s%s.%s", recorded, s3s.config.CsvConfig.CustomFileName, ending)
+		}
 	}
 	if s3s.config.FlatFileConfig != nil {
 		ending = "txt"
+		if s3s.config.FlatFileConfig.CustomFileName != "" {
+			filename = fmt.Sprintf("%s%s.%s", recorded, s3s.config.FlatFileConfig.CustomFileName, ending)
+		}
 	}
 	if s3s.config.ParquetConfig != nil {
 		ending = "parquet"
@@ -311,8 +319,9 @@ func (s3s *S3Storage) createKey(entities []*uda.Entity, fullSync bool) string {
 			}
 		}
 	}
-
-	filename := fmt.Sprintf("%s%s.%s", recorded, uuid.New().String(), ending)
+	if filename == "" {
+		filename = fmt.Sprintf("%s%s.%s", recorded, uuid.New().String(), ending)
+	}
 	return fmt.Sprintf("datasets/%s/%s/%s", s3s.dataset, t, filename)
 }
 


### PR DESCRIPTION
If the files of given postfix is synced to the same folder with different jobs, this PR will make it easier to separate the outputs with a glance.